### PR TITLE
deps: update simple-logger to 1.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ sysinfo = { version = "0.14.5", optional = true }
 rand = "0.7.3"
 rand_xorshift = "0.2.0"
 futures = "0.3.5"
-simple_logger = "1.6.0"
+simple_logger = "1.11.0"
 ctor = "0.1.16"


### PR DESCRIPTION
With the older version 1.6.0, the SimpleLogger structure
was private for some reason, so this project wouldn't
compile.

Fixes https://github.com/tokahuke/yaque/issues/4#issuecomment-743801697