### PR TITLE
Release v0.6.5

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "alltogther",
         "Asbt",
         "Deque",
         "inotify",

--- a/changelog.md
+++ b/changelog.md
@@ -51,7 +51,7 @@ state.
 ## Version 0.4.3:
 
 * Small improvements to docs.
-* Unittests will perform correctly after a previous run was interrupted by 
+* Unit tests will perform correctly after a previous run was interrupted by 
 CTRL+C.
 * Created the `recovery::recover` function for a "full course" queue recover in
 a single command.
@@ -60,7 +60,7 @@ a single command.
 
 * `recv_timeout` and `recv_batch_timeout` to allow receiving with timeout.
 * `recv_batch` is "atomic in an asynchronous context".
-* Now, unlock works even if the process respawns with the same PID.
+* Now, unlock works even if the process re-spawns with the same PID.
 * Recovery of queue works with two modes: replay, which is the behavior of 
 `recovery::recover`, and "with loss", that discards the bottom segment entirely
 (a bit extreme, but we will work on that). Use the
@@ -78,7 +78,7 @@ is only supported within the same _minor_ version.
 
 ## Version 0.5.1:
 
-* Corrected a bug on the `send_metadata` inferrence thingy. Now, all tests are passing.
+* Corrected a bug on the `send_metadata` inference thingy. Now, all tests are passing.
 
 ## Version 0.6.0:
 
@@ -89,7 +89,7 @@ used to ensure "legacy mode", where no parity checking took place. Now, it is a 
 bit all on itself. This leads to much more robust error detection (up to 2bits,
 guaranteed, but you can get lucky with more!).
 * Now you can control the sender more finely with `SenderBuilder`. This includes
-chosing a segment size that fits your needs and chosing the "maximum size" for the
+choosing a segment size that fits your needs and choosing the "maximum size" for the
 queue.
 * And yes, now you can control maximum queue size so that `yaque` doesn't blow up your
 hard drive. This means that some major API changes took place:
@@ -113,14 +113,14 @@ transaction. I could not verify if this invariant always holds. Anyway, there is
 assertion in the code to avoid the worse. If you find such a situation, please fill an
 issue.
 * Dropping the Receiver forced the `state` to be saved, not the `initial_state` (the
-state at the begining of the current transaction). Now, `Drop` calls `Receiver::save`
+state at the beginning of the current transaction). Now, `Drop` calls `Receiver::save`
 so that the behavior will be always consistent.
-* We have a backup strategy for saving the queue! It invlves no asyc stuff, so it will
-only be triggered at the end of a transction. The current criterion is: save at every
-250 items read or every 350ms, whichever comes first. This should dimiinish greatly
+* We have a backup strategy for saving the queue! It involves no async stuff, so it will
+only be triggered at the end of a transaction. The current criterion is: save at every
+250 items read or every 350ms, whichever comes first. This should diminish greatly
 the necessity for external control of the save mechanism.
-* Created a `ReceiverBuilder` to allow people to costumize the way the queue is saved.
-This includes altering the above defaults or disabling queue saving altogther.
+* Created a `ReceiverBuilder` to allow people to customize the way the queue is saved.
+This includes altering the above defaults or disabling queue saving altogether.
 
 
 ## Version 0.6.2:
@@ -143,8 +143,20 @@ leading to clearer code.
 
 ## Version 0.6.4:
 
-* Update dependencies and fix vulerabilities (dependabot).
+* Update dependencies and fix vulnerabilities (dependabot).
 
 ### Contributors:
 
 * [@grant0417](https://github.com/grant0417)
+
+
+## Version 0.6.5:
+
+* Added `Receiver::recv_batch_up_to` and `Receiver::try_recv_batch_up_to` so that you can
+fetch "up to `n`" elements from the queue or wait until one arrives.
+* You can now send and receive empty messages.
+* Fixed typos in the documentation.
+
+### Contributors:
+
+* [@mullr](https://github.com/mullr)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,4 +206,4 @@ pub mod queue;
 pub mod recovery;
 
 pub use error::{TryRecvError, TrySendError};
-pub use queue::{channel, Receiver, ReceiverBuilder, Sender, SenderBuilder, QueueIter};
+pub use queue::{channel, QueueIter, Receiver, ReceiverBuilder, Sender, SenderBuilder};

--- a/src/queue/receiver.rs
+++ b/src/queue/receiver.rs
@@ -64,7 +64,7 @@ impl ReceiverBuilder {
 
     /// Sets the receiver to save its state to the disk at every n-th element.
     /// Set it to `None` to disable this policy.
-    /// 
+    ///
     /// Default value: every 250 elements.
     pub fn save_every_nth(mut self, nth: Option<usize>) -> ReceiverBuilder {
         self.save_every_nth = nth;
@@ -73,11 +73,11 @@ impl ReceiverBuilder {
 
     /// Sets the receiver to save ir state to the disk at every given interval
     /// of time. Set it to `None` to disable this policy.
-    /// 
+    ///
     /// Default value: every 350 milliseconds.
-    /// 
+    ///
     /// # Note:
-    /// 
+    ///
     /// This policy is enforced _synchronously_. This means that there is no
     /// asynchronous behavior involved (i.e. timers). This condition will only
     /// be checked when a new element is pushed to the queue.
@@ -164,7 +164,7 @@ pub struct Receiver {
     read_and_unused: VecDeque<Vec<u8>>,
     /// Save the queue every n operations
     save_every_nth: Option<usize>,
-    /// Save the queue every interval of time. This will be enforced 
+    /// Save the queue every interval of time. This will be enforced
     /// _synchronously_; no timers involved.
     save_every: Option<Duration>,
     /// Number of operations done in this `Receiver`
@@ -326,10 +326,13 @@ impl Receiver {
 
         // With the length, read the data:
         let mut data = vec![0; header.len() as usize];
-        self.tail_follower
-            .read_exact(&mut data)
-            .await
-            .expect("poisoned queue");
+        if header.len() > 0 {
+            // If data size is 0, no need to read any data at all.
+            self.tail_follower
+                .read_exact(&mut data)
+                .await
+                .expect("poisoned queue");
+        }
 
         self.state.advance_position(data.len() as u64);
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -73,7 +73,8 @@ pub fn unlock<P: AsRef<Path>>(lock_filename: P) -> io::Result<()> {
         .expect("failed to parse recv lock file: no token")
         .expect("failed to parse recv lock file: bad token");
 
-    let system = System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()));
+    let system =
+        System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()));
 
     // Maybe somebody else is holding the lock:
     let process_exists_and_is_not_me =

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -129,8 +129,7 @@ pub struct TailFollower {
 
 impl TailFollower {
     /// Creates a new following file.
-    fn new(path: &Path, file: File) -> TailFollower
-    {
+    fn new(path: &Path, file: File) -> TailFollower {
         // Set up waker:
         let waker = Arc::new(Mutex::new(None));
 
@@ -148,8 +147,7 @@ impl TailFollower {
     /// Tries to open a file for reading, creating it, if necessary. This is
     /// not atomic: someone might sneak in just in the right moment and delete
     /// the file before we open it for reading. To prevent this, use a lockfile.
-    pub fn open(path: &Path) -> io::Result<TailFollower>
-    {
+    pub fn open(path: &Path) -> io::Result<TailFollower> {
         let file = open_new(&path)?;
 
         Ok(TailFollower::new(path, file))

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -83,8 +83,7 @@ where
 }
 
 /// Watches *any* removal in a given path.
-pub(crate) fn removal_watcher(path: &Path, waker: Arc<Mutex<Option<Waker>>>) -> RecommendedWatcher
-{
+pub(crate) fn removal_watcher(path: &Path, waker: Arc<Mutex<Option<Waker>>>) -> RecommendedWatcher {
     // Set up watcher:
     let mut watcher =
         notify::recommended_watcher(move |maybe_event: notify::Result<notify::Event>| {
@@ -113,8 +112,7 @@ pub(crate) fn removal_watcher(path: &Path, waker: Arc<Mutex<Option<Waker>>>) -> 
 }
 
 /// Watches a file for changes in its content.
-pub(crate) fn file_watcher(path: &Path, waker: Arc<Mutex<Option<Waker>>>) -> RecommendedWatcher
-{
+pub(crate) fn file_watcher(path: &Path, waker: Arc<Mutex<Option<Waker>>>) -> RecommendedWatcher {
     // Set up watcher:
     let mut watcher =
         notify::recommended_watcher(move |maybe_event: notify::Result<notify::Event>| {


### PR DESCRIPTION
* Added `Receiver::recv_batch_up_to` and `Receiver::try_recv_batch_up_to` so that you can
fetch "up to `n`" elements from the queue or wait until one arrives.
* You can now send and receive empty messages.
* Fixed typos in the documentation.
