### PR TITLE
feat: allow for disabling crossbeam-channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,15 @@ exclude = ["data"]
 resolver = "2"
 
 [features]
-default = ["recovery", "log-trace"]
+default = ["recovery", "log-trace", "crossbeam-channel"]
 recovery = ["sysinfo"]
 log-trace = []  # test only 
 log-debug = []  # test only
+crossbeam-channel = ["notify/default"]
+no-crossbeam-channel = ["notify/macos_kqueue"]
 
 [dependencies]
-notify = "5.1.0"
+notify = { version = "5.1.0", default-features = false }
 log = "0.4.17"
 sysinfo = { version = "0.28.0", default-features = false, optional = true }
 futures = "0.3.26"


### PR DESCRIPTION
As it turns out, `tokio` does not mix well with `notify` when `crossbeam-channels` are enabled (see [here](https://docs.rs/notify/latest/notify/#crossbeam-channel--tokio)).

In my tests with `yaque` added this way to my deps, it seems to work as expected (with this PR in place):
```toml
yaque = { version = "0.6.6", default-features = false, features = ["no-crossbeam-channel"] }
```

Fixes #32 